### PR TITLE
Fixed pointers not being initialized in FFMODAssetTable constructor which lead to crashes on random

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODAssetTable.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODAssetTable.cpp
@@ -19,6 +19,12 @@
 #include "Misc/Paths.h"
 #include "UObject/Package.h"
 
+FFMODAssetTable::FFMODAssetTable()
+	: BankLookup(nullptr)
+	, AssetLookup(nullptr)
+{
+}
+
 void FFMODAssetTable::AddReferencedObjects(FReferenceCollector& Collector)
 {
     // The garbage collector will clean up any objects which aren't referenced, doing this tells the garbage collector our lookups are referenced

--- a/FMODStudio/Source/FMODStudio/Private/FMODAssetTable.h
+++ b/FMODStudio/Source/FMODStudio/Private/FMODAssetTable.h
@@ -12,6 +12,8 @@ class UFMODBankLookup;
 class FFMODAssetTable : public FGCObject
 {
 public:
+	FFMODAssetTable();
+
     //~ FGCObject
     void AddReferencedObjects(FReferenceCollector& Collector) override;
 


### PR DESCRIPTION
_BankLookup_ and _AssetLookup_ pointers were not initialized to nullptr in _FFMODAssetTable_ constructor so they contain garbage until _FFMODAssetTable::Load_ is called. They are not accessed by the integration before doing so, but if the loading takes long enough time (in our case because of a slow server cooking assets on the fly), garbage collection may run before the _FFMODAssetTable::Load_ method gets called and the _BankLookup_ and _AssetLookup_ pointers reference nonexistent objects which leads to a crash.

This fix simply initializes the pointers in the constructor to nullptr so that if the _FFMODAssetTable::AddReferencedObjects_ method gets called before the _FFMODAssetTable::Load_ method the asset table will not reference anything.